### PR TITLE
(feat) Added Nginx load balancer for REST services

### DIFF
--- a/asset-service/src/api/healthCheck/healthCheckRouter.ts
+++ b/asset-service/src/api/healthCheck/healthCheckRouter.ts
@@ -17,6 +17,7 @@ healthCheckRegistry.registerPath({
 });
 
 healthCheckRouter.get("/", (_req: Request, res: Response) => {
+  console.log("Health check request received");
   const serviceResponse = ServiceResponse.success("Service is healthy", null);
   return handleServiceResponse(serviceResponse, res);
 });

--- a/asset-service/src/api/healthCheck/healthCheckRouter.ts
+++ b/asset-service/src/api/healthCheck/healthCheckRouter.ts
@@ -17,7 +17,7 @@ healthCheckRegistry.registerPath({
 });
 
 healthCheckRouter.get("/", (_req: Request, res: Response) => {
-  console.log("Health check request received");
+  console.log("💛 Health check request received");
   const serviceResponse = ServiceResponse.success("Service is healthy", null);
   return handleServiceResponse(serviceResponse, res);
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,11 +37,8 @@ services:
     build:
       context: ./
       dockerfile: ./asset-service/Dockerfile
-    container_name: asset-service
     expose:
       - "5001"
-    ports:
-      - "5001:5001"
     environment:
       PORT: 5001
       JWT_SECRET: "kw9p4Q8JbR9kF5J1NwFd"
@@ -52,11 +49,8 @@ services:
     build:
       context: ./
       dockerfile: ./notification-service/Dockerfile
-    container_name: notification-service
     expose:
       - "5002"
-    ports:
-      - "5002:5002"
     environment:
       RABBITMQ_URL: "amqp://rabbitmq:5672"
       RABBITMQ_QUEUE: "notification_queue"
@@ -71,11 +65,8 @@ services:
     build:
       context: ./
       dockerfile: ./reply-service/Dockerfile
-    container_name: reply-service
     expose:
       - "5003"
-    ports:
-      - "5003:5003"
     environment:
       PORT: 5003
       JWT_SECRET: "kw9p4Q8JbR9kF5J1NwFd"
@@ -169,6 +160,22 @@ services:
       - ./grafana/provisioning:/etc/grafana/provisioning
     depends_on:
       - postgres
+    networks:
+      - intania-overflow-network
+
+  load-balancer:
+    image: nginx:alpine
+    container_name: load-balancer
+    volumes:
+      - ./load-balancer/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - asset-service
+      - notification-service
+      - reply-service
+    ports:
+      - "5001:5001"
+      - "5002:5002"
+      - "5003:5003"
     networks:
       - intania-overflow-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - intania-overflow-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U yourusername"]
+      test: [ "CMD-SHELL", "pg_isready" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -44,6 +44,9 @@ services:
       JWT_SECRET: "kw9p4Q8JbR9kF5J1NwFd"
     networks:
       - intania-overflow-network
+    deploy:
+      mode: replicated
+      replicas: 3
 
   notification-service:
     build:

--- a/load-balancer/nginx.conf
+++ b/load-balancer/nginx.conf
@@ -1,0 +1,24 @@
+user  nginx;
+events {
+    worker_connections   1000;
+}
+http {
+        server {
+              listen 5001;
+              location / {
+                proxy_pass http://asset-service:5001;
+              }
+        }
+        server {
+              listen 5002;
+              location / {
+                proxy_pass http://notification-service:5002;
+              }
+        }
+        server {
+              listen 5003;
+              location / {
+                proxy_pass http://reply-service:5003;
+              }
+        }
+}


### PR DESCRIPTION
1. Remove port mapping from docker containers
2. Add load balancer to mediate traffics (host can access services via load balancer)

(This works only with REST API-based services)