### PR TITLE
fix: ensure isThread query param is parsed to boolean in voting-service in gateway

### DIFF
--- a/api-gateway/src/controllers/voting-controller.ts
+++ b/api-gateway/src/controllers/voting-controller.ts
@@ -86,7 +86,6 @@ export const applyDownvote = controllerWrapper(async (req: any, res: any) => {
 // Check user vote status
 export const checkVoteStatus = controllerWrapper(async (req: any, res: any) => {
   const token = validateAuth(req);
-  // const { isThread, targetId } = req.query;
   const { targetId } = req.query;
   const isThread = req.query.isThread === 'true';
 

--- a/api-gateway/src/controllers/voting-controller.ts
+++ b/api-gateway/src/controllers/voting-controller.ts
@@ -7,7 +7,8 @@ const grpcRequest = getGrpcRequest(votingClient);
 
 // Get current vote counts
 export const getVotes = controllerWrapper(async (req: any, res: any) => {
-  const { isThread, targetId } = req.query;
+  const { targetId } = req.query;
+  const isThread = req.query.isThread === 'true';
 
   if (!targetId) {
     res.status(400).json({ error: "targetId is required" });
@@ -85,7 +86,9 @@ export const applyDownvote = controllerWrapper(async (req: any, res: any) => {
 // Check user vote status
 export const checkVoteStatus = controllerWrapper(async (req: any, res: any) => {
   const token = validateAuth(req);
-  const { isThread, targetId } = req.query;
+  // const { isThread, targetId } = req.query;
+  const { targetId } = req.query;
+  const isThread = req.query.isThread === 'true';
 
   if (!targetId) {
     res.status(400).json({ error: "targetId is required" });

--- a/voting-service/src/repositorys/votingRepository.ts
+++ b/voting-service/src/repositorys/votingRepository.ts
@@ -64,14 +64,13 @@ export const applyDownVote = async (
 
 export const getCountVote = async (isThread: boolean, targetId: string) => {
   try {
+    const query = { targetId, isThread: isThread };
     const upVotes = await Vote.countDocuments({
-      isThread,
-      targetId,
+      ...query,
       isUpVote: true,
     });
     const downVotes = await Vote.countDocuments({
-      isThread,
-      targetId,
+      ...query,
       isUpVote: false,
     });
     const netVotes = upVotes - downVotes;


### PR DESCRIPTION
1. Parsing isThread query parameter:
        - Updated the handling of the isThread query parameter to reliably parse it as a boolean.

2. Updated voting service query method:
        - Made adjustments to the query method in the voting service to reflect this boolean change and ensure the correct behavior in the service logic.